### PR TITLE
replace deprecated `mix`

### DIFF
--- a/boingg.lua
+++ b/boingg.lua
@@ -244,7 +244,7 @@ end
 
 function enc(n, d)
   if n == 1 then
-    mix:delta("output", d)
+    params:delta("output_level", d)
     redraw()
   elseif n == 2 then
     current_cycle = util.clamp(current_cycle + d, 1, 16)


### PR DESCRIPTION
swapped `mix:delta("output", d)` with `params:delta("output_level", d)`. unsure if you want to further clamp to unity, but at least this won't error! :)